### PR TITLE
close server when exit

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -60,6 +60,12 @@ router.get('/ask/stream', async (ctx) => {
 
 app.use(router.routes());
 
-app.listen(3000, () => {
+const server = app.listen(3000, () => {
     console.log("Now listening: 127.0.0.1:3000");
+});
+
+process.on('SIGINT', () => {
+    server.close(() => {
+        process.exit(0);
+    });
 });


### PR DESCRIPTION
Handle the SIGINT signal (such as when the user presses Ctrl+C in the terminal) by first closing the server and then exiting the program.